### PR TITLE
Try loading environment variables from .env to fetch settings module

### DIFF
--- a/djangonaut.el
+++ b/djangonaut.el
@@ -673,6 +673,12 @@ if not sys.path[0]:
     del sys.path[0]
 
 try:
+    import dotenv
+    dotenv.load_dotenv()
+except ModuleNotFoundError:
+    pass
+
+try:
     from django.apps import apps
     from django.conf import settings
     apps.populate(settings.INSTALLED_APPS)


### PR DESCRIPTION
Hello, thanks for the wonderful project:)

I had a problem using the `find-*` functions because they could not find my project's settings module. When running the project itself, I use `python-dotenv` to set the `DJANGO_SETTINGS_MODULE` environment variable, and thus tell Django where the settings module is.

This PR makes djangonaut pick up the `.env` file on every command. It adds a minor unfelt overhead to every command, but I would understand if you wouldn't appreciate it, so I want to bring this up for discussion: do you use this workflow? if no, then how do you separate between production and development environments?

Another possible solution is to add a `djangonaut-dotenv-p` boolean variable, which will toggle this behaviour.

What do you think?